### PR TITLE
Removing dependabot config for go modules

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,13 +1,6 @@
 version: 2
 updates:
   -
-    package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
-  -
     package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
When tekton was updated the go mod and sum files were removed as
they are not needed. Without them we do not need dependabot looking
to update them. For ref see https://github.com/rancher/build-tekton/pull/30