### PR TITLE
Switch Tektoncd Pipeline to v0.36.0

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ FROM registry.suse.com/bci/golang:1.18
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-ENV TEKTON_TAG v0.38.2
+ENV TEKTON_TAG v0.36.0
 
 RUN zypper -n install --no-recommends git docker vim curl wget ca-certificates
 RUN mkdir -p /go/src/github.com/tektoncd/pipeline && \


### PR DESCRIPTION
from June 2022.

https://github.com/tektoncd/pipeline/releases/tag/v0.36.0

Later versions are incompatible with Fleet at the moment.