### PR TITLE
Bump TektonCD Pipeline to v0.41.0

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ FROM registry.suse.com/bci/golang:1.20
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-ENV TEKTON_TAG v0.38.3
+ENV TEKTON_TAG v0.41.0
 
 RUN zypper -n install --no-recommends git docker vim curl wget ca-certificates
 RUN mkdir -p /go/src/github.com/tektoncd/pipeline && \


### PR DESCRIPTION
That version is the first LTS following v0.40.0, which fixes [this issue](https://github.com/tektoncd/pipeline/issues/5429) whereby HTTP repo URLs are detected as SSH URLs.

Bumping to the latest version is not an option at this point, as it removes `git-init` code. There are [plans](https://github.com/tektoncd-catalog/git-clone/issues/2) to migrate that code to a new repository, so we will most likely want to watch that space and update our build scripts accordingly.