### PR TITLE
Reference only the minor version of the bci image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.5.36.5.54
+FROM registry.suse.com/bci/bci-base:15.5
 RUN zypper -n update && \
     zypper -n install --no-recommends openssh git && \
     zypper -n clean -a


### PR DESCRIPTION
to make sure that on each release the latest version is used.